### PR TITLE
#815

### DIFF
--- a/solutions/815. Bus Routes/script.ts
+++ b/solutions/815. Bus Routes/script.ts
@@ -11,7 +11,6 @@ function numBusesToDestination(routes: number[][], source: number, target: numbe
 
     const queue: number[] = [...graph.getNeighbours(source).keys()]
     const visitedRoutes: Set<number> = new Set<number>([...graph.getNeighbours(source).keys()])
-    const visitedStops: Set<number> = new Set<number>([source])
 
     let busCount: number = 1
     while (queue.length > 0) {
@@ -31,8 +30,6 @@ function numBusesToDestination(routes: number[][], source: number, target: numbe
                         queue.push(nextRoute)
                     }
                 }
-
-                visitedStops.add(stop)
             }
         }
 

--- a/solutions/815. Bus Routes/script.ts
+++ b/solutions/815. Bus Routes/script.ts
@@ -10,7 +10,7 @@ function numBusesToDestination(routes: number[][], source: number, target: numbe
     const graph: DirectedUnweightedGraph = buildRoutes(routes)
 
     const queue: number[] = [...graph.getNeighbours(source).keys()]
-    const visitedRoutes: Set<number> = new Set<number>([...graph.getNeighbours(source).keys()])
+    const visitedRoutes: Set<number> = new Set<number>(graph.getNeighbours(source).keys())
 
     let busCount: number = 1
     while (queue.length > 0) {
@@ -42,7 +42,7 @@ function numBusesToDestination(routes: number[][], source: number, target: numbe
 function buildRoutes(buses: number[][]): DirectedUnweightedGraph {
     const graph: DirectedUnweightedGraph = new DirectedUnweightedGraph()
 
-    for (let bus = 0; bus < buses.length; bus++) {
+    for (let bus:number = 0; bus < buses.length; bus++) {
         for (const stop of buses[bus]) {
             graph.addEdge(stop, bus)
         }


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Fixes an issue where the algorithm revisits stops, leading to incorrect bus counts by removing the `visitedStops` set.